### PR TITLE
Add scan function to dynamodb lib

### DIFF
--- a/src/app/testing/jest/frontend/utils/dynamodb-lib.test.ts
+++ b/src/app/testing/jest/frontend/utils/dynamodb-lib.test.ts
@@ -1,5 +1,9 @@
 import dynamoLib from "../../../../utils/dynamodb-lib";
-import { GetCommand, DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import {
+  GetCommand,
+  DynamoDBDocumentClient,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
@@ -15,5 +19,14 @@ describe("Test DynamoDB lib", () => {
     await dynamoLib.get({ TableName: "foos", Key: { id: "foo1" } });
 
     expect(mockGet).toHaveBeenCalled();
+  });
+
+  test("Can perform a single scan", async () => {
+    const mockItem = { foo: "bar" };
+    dynamoClientMock.on(ScanCommand).resolves({ Items: [mockItem] });
+
+    const result = await dynamoLib.singleScan({ TableName: "foos" });
+
+    expect(result.Items?.[0]).toBe(mockItem);
   });
 });

--- a/src/app/utils/dynamodb-lib.ts
+++ b/src/app/utils/dynamodb-lib.ts
@@ -3,6 +3,8 @@ import {
   GetCommand,
   GetCommandInput,
   DynamoDBDocumentClient,
+  ScanCommand,
+  ScanCommandInput,
 } from "@aws-sdk/lib-dynamodb";
 
 const awsConfig = {
@@ -14,6 +16,9 @@ const client = DynamoDBDocumentClient.from(new DynamoDBClient(awsConfig));
 const dynamoClient = {
   get: async function (params: GetCommandInput) {
     return await client.send(new GetCommand(params));
+  },
+  singleScan: async function (params: ScanCommandInput) {
+    return await client.send(new ScanCommand(params));
   },
 };
 


### PR DESCRIPTION
# Summary

- Adds the ability to perform a single scan of a given database (from which we can perform additional scans from where we left off)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #24 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How To Test
Temporarily modify the PageHeader file as follows
```js
import dynamoClient from "../../utils/dynamodb-lib";

export const PageHeader = async () => {
  const params = {
    TableName: "institutions",
    Limit: 10,
  };
  const result = await dynamoClient.singleScan(params);
  console.log("result", result);
  console.log("items", result.Items);
  console.log("length of items", result?.Items?.length);
```

- Export AWS credentials in your terminal
- Run `yarn dev`
- Load the webpage
- Verify that your terminal (where you ran yarn dev) outputs records from the table, no more than 10 (may be fewer if table has fewer than 10)

# Checklist:

- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, including any applicable ADRs
- [x] My changes generate no new warnings
- [x] I have added tests that fail without these changes
- [x] New and existing tests (unit, integration, accessibility) pass locally
- [x] Documentation updated
- [x] If there are security concerns they are addressed or ticketed after being discussed
