### PR TITLE
Bugfix/Bring back accessibility tests for CardIcon and CollegeCard

### DIFF
--- a/src/app/testing/jest/frontend/components/cards/CardIcon.test.tsx
+++ b/src/app/testing/jest/frontend/components/cards/CardIcon.test.tsx
@@ -1,5 +1,6 @@
 import { CardIcon } from "@/src/app/components";
 import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
 
 const component = (
   <CardIcon subtitle={"Example Subtitle"} highlight={"Example Highlight"} />
@@ -16,5 +17,13 @@ describe("Test CardIcon", () => {
 
   test("CardIcon Highlight is visible", () => {
     expect(screen.getByText("Example Highlight")).toBeVisible();
+  });
+});
+
+describe("Test CollegeCard accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(component);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/src/app/testing/jest/frontend/components/cards/CollegeCard.test.tsx
+++ b/src/app/testing/jest/frontend/components/cards/CollegeCard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { College, CollegeType } from "@/src/app/types";
 import { CollegeCard } from "@/src/app/components";
+import { axe } from "jest-axe";
 
 const college: College = {
   id: 0,
@@ -15,7 +16,11 @@ const college: College = {
   avgCost: 17980,
 };
 
-const component = <CollegeCard college={college} />;
+const component = (
+  <ul>
+    <CollegeCard college={college} />
+  </ul>
+);
 
 describe("Test CollegeCard", () => {
   beforeEach(() => {
@@ -30,5 +35,13 @@ describe("Test CollegeCard", () => {
     expect(screen.getByText(college.populationAmount)).toBeVisible();
     expect(screen.getByText(college.gradRate)).toBeVisible();
     expect(screen.getByText(college.avgCost)).toBeVisible();
+  });
+});
+
+describe("Test CollegeCard accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(component);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });


### PR DESCRIPTION
# Title
Bring back accessibility tests for CardIcon and CollegeCard

# Summary

When creating the CardIcon and CollegeCard, we opted to not include accessibility tests as the page would check it. After deliberation, we decided to ensure its tested fully and include them in the unit tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How To Test

1. `yarn test`
2. Ensure all tests pass without error

# Checklist:

- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation, including any applicable ADRs
- [x] My changes generate no new warnings
- [x] I have added tests that fail without these changes
- [x] New and existing tests (unit, integration, accessibility) pass locally
- ~[ ] Documentation updated
- ~[ ] If there are security concerns they are addressed or ticketed after being discussed
