### PR TITLE
Issue/remove more info

### DIFF
--- a/src/app/components/cards/CollegeCard.tsx
+++ b/src/app/components/cards/CollegeCard.tsx
@@ -37,9 +37,8 @@ export const CollegeCard = ({ college }: Props) => {
       </CardBody>
       <CardFooter>
         <ButtonGroup>
-          <Button type={"button"}>Apply to this school</Button>
-          <Button type={"button"} outline={true}>
-            More information
+          <Button name="apply" type={"button"}>
+            Apply to this school
           </Button>
         </ButtonGroup>
       </CardFooter>

--- a/src/app/testing/jest/frontend/components/cards/CollegeCard.test.tsx
+++ b/src/app/testing/jest/frontend/components/cards/CollegeCard.test.tsx
@@ -31,4 +31,11 @@ describe("Test CollegeCard", () => {
     expect(screen.getByText(college.gradRate)).toBeVisible();
     expect(screen.getByText(college.avgCost)).toBeVisible();
   });
+
+  test("CollegeCard should have apply button", () => {
+    expect(screen.getByRole("button", { name: /apply/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: /apply/i })).toHaveValue(
+      "Apply to this school",
+    );
+  });
 });

--- a/src/app/testing/jest/frontend/components/cards/CollegeCard.test.tsx
+++ b/src/app/testing/jest/frontend/components/cards/CollegeCard.test.tsx
@@ -34,8 +34,12 @@ describe("Test CollegeCard", () => {
 
   test("CollegeCard should have apply button", () => {
     expect(screen.getByRole("button", { name: /apply/i })).toBeVisible();
-    expect(screen.getByRole("button", { name: /apply/i })).toHaveValue(
+    expect(screen.getByRole("button", { name: /apply/i })).toHaveTextContent(
       "Apply to this school",
     );
+  });
+
+  test("CollegeCard button group should have one button", () => {
+    expect(screen.getAllByRole("button")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
# Remove more info button

# Summary
The more info button was on the original mockups but we're not ready for it yet
Closes # 76

<img width="1130" alt="image" src="https://github.com/coforma/swift-tech-challenge/assets/7631428/aedaf270-5589-42be-8f00-1d127c2462e9">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How To Test
1. Run the app
2. Ensure the more info button is not there

# Checklist:

- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, including any applicable ADRs
- [x] My changes generate no new warnings
- [x] I have added tests that fail without these changes
- [x] New and existing tests (unit, integration, accessibility) pass locally
- [x] Documentation updated
- [x] If there are security concerns they are addressed or ticketed after being discussed
