### PR TITLE
Issue (#79) Terraform backend

### DIFF
--- a/tf/modules/frontend/lambda.tf
+++ b/tf/modules/frontend/lambda.tf
@@ -1,36 +1,38 @@
-
-
 resource "aws_iam_role" "iam_for_lambda" {
   name               = format("%sFrontendLambdaRole", title(var.environment))
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-#Policy Doc for creating logs in CloudWatch
-data "aws_iam_policy_document" "logging" {
+resource "aws_iam_role_policy_attachment" "exec" {
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole"
+}
+
+data "aws_iam_policy_document" "backend" {
   statement {
-    effect    = "Allow"
-    actions   = ["logs:CreateGroup"]
-    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
-  }
-  statement {
+    sid    = "ReadDynamoDB"
     effect = "Allow"
     actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
+      "dynamodb:GetItem",
+      "dynamodb:BatchGetItem",
+      "dynamodb:Scan",
+      "dynamodb:Query",
+      "dynamodb:ConditionCheckItem"
     ]
-    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:aws/lambda/${aws_lambda_function.frontend.function_name}:*"]
+    resources = [
+      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.institutions_dynamodb_table}"
+    ]
   }
 }
 
-resource "aws_iam_policy" "logging" {
-  name        = format("%sFrontendLoggingPolicy", title(var.environment))
-  description = "Allows creating and writing to Frontend log group"
-  policy      = data.aws_iam_policy_document.logging.json
+resource "aws_iam_policy" "backend" {
+  policy = data.aws_iam_policy_document.backend.json
+  name   = format("%sAppBackendAccessPolicy", title(var.environment))
 }
 
-resource "aws_iam_role_policy_attachment" "logging" {
+resource "aws_iam_role_policy_attachment" "backend" {
   role       = aws_iam_role.iam_for_lambda.name
-  policy_arn = aws_iam_policy.logging.arn
+  policy_arn = aws_iam_policy.backend.arn
 }
 
 resource "aws_lambda_function" "frontend" {
@@ -51,6 +53,9 @@ resource "aws_lambda_function" "frontend" {
   layers = [
     "arn:aws:lambda:${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:20"
   ]
+  logging_config {
+    log_format = "JSON"
+  }
 }
 
 

--- a/tf/modules/frontend/variables.tf
+++ b/tf/modules/frontend/variables.tf
@@ -32,3 +32,8 @@ variable "github" {
   })
   description = "Github settings for deployment. Requires 'repo', 'app_deploy_restrictions', and 'oidc_arn'"
 }
+
+variable "institutions_dynamodb_table" {
+  type    = string
+  default = "institutions"
+}


### PR DESCRIPTION
* Add required permissions for accessing dynamodb

# Terraform backend - DynamoDB Permissions

# Summary
* Add required permissions for accessing dynamodb

Drops existing execution policy for default AWS lambda dynamo db policy and add some additional permissions for accessing dynamodb.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This is a documentation update

# How To Test

# Checklist:

- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation, including any applicable ADRs~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that fail without these changes~~
~~- [ ] New and existing tests (unit, integration, accessibility) pass locally~~
~~- [ ] Documentation updated~~
~~- [ ] If there are security concerns they are addressed or ticketed after being discussed~~
