### PR TITLE
performs a full scan of the db to load all available institutions

### DIFF
--- a/src/app/testing/jest/frontend/utils/institutions.test.ts
+++ b/src/app/testing/jest/frontend/utils/institutions.test.ts
@@ -1,6 +1,5 @@
 import { CollegeType } from "@/src/app/types";
 import { getInstitutions } from "@/src/app/utils/institutions";
-import s3Lib from "@/src/app/utils/libs/s3-lib";
 import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 
@@ -22,7 +21,6 @@ describe("test institutions utils", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     dynamoClientMock.reset();
-    jest.spyOn(s3Lib, "get").mockResolvedValueOnce("superlongbase64string");
   });
   test("test getInstitutions", async () => {
     dynamoClientMock.on(ScanCommand).resolves({ Items: [mockCollegeDbItem] });

--- a/src/app/utils/institutions.ts
+++ b/src/app/utils/institutions.ts
@@ -1,12 +1,8 @@
 import dynamoClient from "./libs/dynamodb-lib";
-import s3Client from "./libs/s3-lib";
-import emptyPictureIcon from "@/src/app/public/picture_icon.png";
 // types
 import { College } from "../types";
-import { StaticImageData } from "next/image";
 
 const INSTITUTIONS_TABLE_NAME = "institutions";
-const IMAGES_BUCKET_NAME = "swift-institution-images";
 
 export async function getInstitutions() {
   let colleges: College[] = [];
@@ -14,16 +10,14 @@ export async function getInstitutions() {
     TableName: INSTITUTIONS_TABLE_NAME,
     FilterExpression: "recordType = :recordType",
     ExpressionAttributeValues: { ":recordType": "data" },
-    Limit: 4,
   };
-  const result = await dynamoClient.singleScan(params);
-  const items = result?.Items;
+  const items = await dynamoClient.scanAll(params);
 
   if (Array.isArray(items)) {
     for (const item of items) {
       const college: College = {
         id: item?.institutionId,
-        img: await getImage(item?.institutionId),
+        img: "", // image loading addressed separately
         name: item?.institutionName,
         city: item?.city,
         state: item?.state,
@@ -38,17 +32,4 @@ export async function getInstitutions() {
   }
 
   return colleges;
-}
-
-async function getImage(institutionId: Number) {
-  let image: string | StaticImageData = emptyPictureIcon;
-  const params = {
-    Bucket: IMAGES_BUCKET_NAME,
-    Key: `${institutionId}.json`,
-  };
-  const response = await s3Client.get(params);
-  if (response !== "") {
-    image = `data:image/png;base64,${response}`;
-  }
-  return image;
 }

--- a/src/app/utils/libs/dynamodb-lib.ts
+++ b/src/app/utils/libs/dynamodb-lib.ts
@@ -17,8 +17,18 @@ const dynamoClient = {
   get: async function (params: GetCommandInput) {
     return await client.send(new GetCommand(params));
   },
-  singleScan: async function (params: ScanCommandInput) {
-    return await client.send(new ScanCommand(params));
+  scanAll: async function (params: ScanCommandInput) {
+    let items: any[] = [];
+    let ExclusiveStartKey: any;
+
+    do {
+      const command = new ScanCommand({ ...params, ExclusiveStartKey });
+      const result = await client.send(command);
+      items = items.concat(result.Items ?? []);
+      ExclusiveStartKey = result.LastEvaluatedKey;
+    } while (ExclusiveStartKey);
+
+    return items;
   },
 };
 


### PR DESCRIPTION
# Summary

- Remove image loading on DB pull (image loading will be moved to card render similar to #108)
- Add scanAll DB call
- Add test for scanAll

Fixes #109 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How To Test
- Export AWS credentials
- Run `yarn dev`
- Visit localhost:3000 and verify all the institutions load (long list!)
  - Verify the time is not _that_ bad (about .25-.4 seconds) 

Later we will save these in state management so that it is a pull once, which will save time during navigation and filtering.

# Checklist:

- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, including any applicable ADRs
- [x] My changes generate no new warnings
- [x] I have added tests that fail without these changes
- [x] New and existing tests (unit, integration, accessibility) pass locally
- [ ] Documentation updated
- [ ] If there are security concerns they are addressed or ticketed after being discussed