### PR TITLE
Check if lambda is updating before deploying new version

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -52,6 +52,18 @@ jobs:
           role-to-assume: ${{ secrets.DEPLOY_ROLE }}
           aws-region: us-east-1
           role-session-name: GitHubAppDeploy
+      - name: Wait for lambda alias to update
+        if: inputs.wait_enabled == 'true' || inputs.wait_enabled == true
+        timeout-minutes: 5
+        run: |
+          weight="not_null"
+          printf "Waiting on Lambda Alias to update."
+          while [ "$weight" != "null" ];
+          do
+            sleep 5
+            weight=$(aws lambda get-alias --function-name $LAMBDA_NAME --name $LAMBDA_ALIAS | jq -r ".RoutingConfig.AdditionalVersionWeights" )
+            printf "."
+          done
       - name: Update Frontend Lambda Code
         run: |
           ## Update the code from s3

--- a/tf/modules/frontend/lambda.tf
+++ b/tf/modules/frontend/lambda.tf
@@ -86,7 +86,10 @@ resource "aws_lambda_alias" "alias" {
   function_name    = aws_lambda_function.frontend.arn
   function_version = aws_lambda_function.frontend.version
   lifecycle {
-    ignore_changes = [routing_config]
+    ignore_changes = [
+      routing_config,
+      function_version
+    ]
   }
 }
 

--- a/tf/projects/bootstrap/main.tf
+++ b/tf/projects/bootstrap/main.tf
@@ -134,6 +134,17 @@ resource "aws_iam_policy" "tfstate_access" {
         Effect   = "Allow"
         Resource = ["arn:aws:dynamodb:*:*:table/${var.dynamodb_table}"]
       },
+      {
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:secretsmanager:us-east-1:905418154281:secret:test/app/mixpanel*",
+          "arn:aws:secretsmanager:us-east-1:905418154281:secret:stage/app/mixpanel*",
+          "arn:aws:secretsmanager:us-east-1:905418154281:secret:prod/app/mixpanel*"
+        ]
+      }
     ]
   })
 }


### PR DESCRIPTION
# Fix Pipeline race condition

# Summary

Adds a script that polls aws lambda service to check if lambda is still deploying before running update.
Adds permission to validate secret for validator role
Set terraform to ignore changes to lambda alias version
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes # (#124 )

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How To Test
Run pipeline build
# Checklist:

- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation, including any applicable ADRs~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that fail without these changes~~
~~- [ ] New and existing tests (unit, integration, accessibility) pass locally~~
~~- [ ] Documentation updated~~
~~- [ ] If there are security concerns they are addressed or ticketed after being discussed~~
