### PR TITLE
Add confirmation and error pages with tests

### DIFF
--- a/src/app/[id]/apply/confirmation/page.tsx
+++ b/src/app/[id]/apply/confirmation/page.tsx
@@ -1,0 +1,9 @@
+export default function ConfirmationPage({ params }: Props) {
+  return <div>{`Successfully completed application for ${params.id}`}</div>;
+}
+
+type Props = {
+  params: {
+    id: string;
+  };
+};

--- a/src/app/[id]/apply/page.tsx
+++ b/src/app/[id]/apply/page.tsx
@@ -1,6 +1,6 @@
 import { ApplicationForm } from "../../components/form/ApplicationForm";
 
-export default function Page({ params }: Props) {
+export default function ApplyPage({ params }: Props) {
   return <ApplicationForm institutionId={params.id} />;
 }
 

--- a/src/app/components/form/ApplicationForm.tsx
+++ b/src/app/components/form/ApplicationForm.tsx
@@ -12,11 +12,13 @@ import {
 } from "@trussworks/react-uswds";
 import { TextField, TextArea } from "../../components";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 // utils
 import { getInstitutionApplication } from "../../utils/institutions";
 import { saveApplication } from "@/src/app/utils/applications";
 
 export const ApplicationForm = ({ institutionId }: Props) => {
+  const router = useRouter();
   const [application, setApplication] = useState<
     Record<string, any> | undefined
   >();
@@ -31,14 +33,19 @@ export const ApplicationForm = ({ institutionId }: Props) => {
 
   const appq = application?.questions;
 
-  const onSubmit = (data: any) => {
+  const onSubmit = async (data: any) => {
     const submission = {
       questions: appq,
       answers: data,
       email: data.email,
       institutionId: institutionId,
     };
-    saveApplication(submission);
+    try {
+      await saveApplication(submission);
+      router.push(`/${institutionId}/apply/confirmation`);
+    } catch {
+      router.push(`/error`);
+    }
   };
 
   //Handle personal questions

--- a/src/app/error/page.tsx
+++ b/src/app/error/page.tsx
@@ -1,0 +1,15 @@
+import { ButtonGroup, GridContainer } from "@trussworks/react-uswds";
+import Link from "next/link";
+
+export default function ErrorPage() {
+  return (
+    <GridContainer>
+      There was an error
+      <ButtonGroup>
+        <Link href="/" className="usa-button">
+          Visit homepage
+        </Link>
+      </ButtonGroup>
+    </GridContainer>
+  );
+}

--- a/src/app/testing/jest/frontend/ConfirmationPage.test.tsx
+++ b/src/app/testing/jest/frontend/ConfirmationPage.test.tsx
@@ -1,0 +1,24 @@
+import Page from "@/src/app/[id]/apply/confirmation/page";
+import { act, render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+
+const ConfirmationPage = Page({ params: { id: "123" } });
+
+describe("Test Confirmation Page", () => {
+  it("should render the confirmation page", async () => {
+    render(ConfirmationPage);
+    expect(
+      screen.getByText("Successfully completed application for 123"),
+    ).toBeVisible();
+  });
+});
+
+describe("Test Homepage accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    await act(async () => {
+      const { container } = render(ConfirmationPage);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/src/app/testing/jest/frontend/ErrorPage.test.tsx
+++ b/src/app/testing/jest/frontend/ErrorPage.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import ErrorPage from "@/src/app/error/page";
+import { act } from "react-dom/test-utils";
+
+describe("Test Error Page", () => {
+  test("Check that page renders", () => {
+    render(<ErrorPage />);
+    expect(screen.getByText("There was an error")).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: "Visit homepage" }),
+    ).toHaveAttribute("href", "/");
+  });
+});
+
+describe("Test Error page accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(<ErrorPage />);
+    await act(async () => {
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});


### PR DESCRIPTION
# Summary

- Add confirmation page and navigate to it upon successful form submission
- Add error page if form submission fails
- Add tests

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #74

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How To Test
- Go to a form application (may need to add `/apply` from a details page while we work on routing)
- Type in anything and submit the form
- Verify it goes to the confirmation page (which will be built out later

- Navigate to `/error`
- Verify the error page shows with a link back home

# Checklist:

- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, including any applicable ADRs
- [x] My changes generate no new warnings
- [x] I have added tests that fail without these changes
- [x] New and existing tests (unit, integration, accessibility) pass locally
- [ ] Documentation updated
- [ ] If there are security concerns they are addressed or ticketed after being discussed
