### PR TITLE
Expose data object in provider alongside array

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,25 +1,32 @@
 const nextConfig = {
+  reactStrictMode: false,
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'swift-institution-images-public.s3.amazonaws.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "swift-institution-images-public.s3.amazonaws.com",
+        port: "",
+        pathname: "/**",
       },
     ],
-    minimumCacheTTL: 86400
+    minimumCacheTTL: 86400,
   },
   sassOptions: {
     includePaths: ["./node_modules/@uswds/uswds/packages"],
   },
-  output: 'standalone',
+  output: "standalone",
   experimental: {
     serverActions: {
-      allowedForwardedHosts: ["luf1zbs5oa.execute-api.us-east-1.amazonaws.com","rm93rrjzid.execute-api.us-east-1.amazonaws.com"],
-      allowedOrigins: ["d1b4twxh1cihpk.cloudfront.net","d2z6xcoh14f3wb.cloudfront.net"],
-    }
-  }
+      allowedForwardedHosts: [
+        "luf1zbs5oa.execute-api.us-east-1.amazonaws.com",
+        "rm93rrjzid.execute-api.us-east-1.amazonaws.com",
+      ],
+      allowedOrigins: [
+        "d1b4twxh1cihpk.cloudfront.net",
+        "d2z6xcoh14f3wb.cloudfront.net",
+      ],
+    },
+  },
 };
 
 export default nextConfig;

--- a/src/app/[id]/apply/confirmation/page.tsx
+++ b/src/app/[id]/apply/confirmation/page.tsx
@@ -10,20 +10,20 @@ import ErrorPage from "@/src/app/error/page";
 // types
 import { College } from "@/src/app/types";
 
-const filterCollege = (institutionData: College[], id: number) => {
-  return institutionData.filter((college) => college.id == id)[0];
+const filterCollege = (institutionsArray: College[], id: number) => {
+  return institutionsArray.filter((college) => college.id == id)[0];
 };
 
 export default function ConfirmationPage({ params }: Props) {
-  const { institutionData } = useContext(InstitutionContext);
+  const { institutionsArray } = useContext(InstitutionContext);
   const [loading, setLoading] = useState(true);
   const [selectedCollege, setSelectedCollege] = useState<College>();
   useEffect(() => {
-    if (institutionData) {
-      setSelectedCollege(filterCollege(institutionData!, params.id));
+    if (institutionsArray) {
+      setSelectedCollege(filterCollege(institutionsArray!, params.id));
       setLoading(false);
     }
-  }, [institutionData, params.id]);
+  }, [institutionsArray, params.id]);
 
   const view = () => {
     return !selectedCollege ? (

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -10,8 +10,8 @@ import NotFound from "@/src/app/not-found";
 // types
 import { College } from "../types";
 
-const filterCollege = (institutionData: College[], id: number) => {
-  return institutionData.filter((college) => college.id == id)[0];
+const filterCollege = (institutionsArray: College[], id: number) => {
+  return institutionsArray.filter((college) => college.id == id)[0];
 };
 
 export default function InstitutionDetails({
@@ -19,15 +19,15 @@ export default function InstitutionDetails({
 }: {
   params: { id: number };
 }) {
-  const { institutionData } = useContext(InstitutionContext);
+  const { institutionsArray } = useContext(InstitutionContext);
   const [loading, setLoading] = useState(true);
   const [selectedCollege, setSelectedCollege] = useState<College>();
   useEffect(() => {
-    if (institutionData) {
-      setSelectedCollege(filterCollege(institutionData!, params.id));
+    if (institutionsArray) {
+      setSelectedCollege(filterCollege(institutionsArray!, params.id));
       setLoading(false);
     }
-  }, [institutionData, params.id]);
+  }, [institutionsArray, params.id]);
 
   const view = () => {
     return !selectedCollege ? (

--- a/src/app/components/institutions/InstitutionProvider.tsx
+++ b/src/app/components/institutions/InstitutionProvider.tsx
@@ -5,22 +5,23 @@ import { getInstitutions } from "@/src/app/utils/institutions";
 import { College } from "../../types";
 
 export interface InstitutionContextShape {
-  institutionData: College[] | undefined;
+  institutionsArray: College[] | undefined;
 }
 
 export const InstitutionContext = createContext<InstitutionContextShape>({
-  institutionData: undefined as College[] | undefined,
+  institutionsArray: undefined as College[] | undefined,
 });
 
 export const InstitutionProvider = ({ children }: Props) => {
-  const [institutionData, setInstitutionData] = useState<
+  const [institutionsArray, setInstitutionsArray] = useState<
     College[] | undefined
   >();
 
   const fetchInstitutions = async () => {
     try {
       const result = await getInstitutions();
-      setInstitutionData(result);
+      setInstitutionsArray(result);
+      // TODO: setInstitutionsObj();
     } catch (e: any) {
       throw new Error("Institution data could not be loaded.");
     }
@@ -32,9 +33,9 @@ export const InstitutionProvider = ({ children }: Props) => {
 
   const providerValue = useMemo(
     () => ({
-      institutionData,
+      institutionsArray,
     }),
-    [institutionData],
+    [institutionsArray],
   );
 
   return (

--- a/src/app/components/institutions/InstitutionProvider.tsx
+++ b/src/app/components/institutions/InstitutionProvider.tsx
@@ -6,22 +6,32 @@ import { College } from "../../types";
 
 export interface InstitutionContextShape {
   institutionsArray: College[] | undefined;
+  institutionsObject: { [key: string]: College } | undefined;
 }
 
 export const InstitutionContext = createContext<InstitutionContextShape>({
   institutionsArray: undefined as College[] | undefined,
+  institutionsObject: undefined as { [key: string]: College } | undefined,
 });
 
 export const InstitutionProvider = ({ children }: Props) => {
   const [institutionsArray, setInstitutionsArray] = useState<
     College[] | undefined
   >();
+  const [institutionsObject, setInstitutionsObject] = useState<
+    { [key: string]: College } | undefined
+  >();
 
   const fetchInstitutions = async () => {
     try {
       const result = await getInstitutions();
       setInstitutionsArray(result);
-      // TODO: setInstitutionsObj();
+      // create object from array, indexed by institution id
+      const objectForm: { [key: string]: College } = result.reduce(
+        (acc, val) => ({ ...acc, [val.id]: val }),
+        {},
+      );
+      setInstitutionsObject(objectForm);
     } catch (e: any) {
       throw new Error("Institution data could not be loaded.");
     }
@@ -34,8 +44,9 @@ export const InstitutionProvider = ({ children }: Props) => {
   const providerValue = useMemo(
     () => ({
       institutionsArray,
+      institutionsObject,
     }),
-    [institutionsArray],
+    [institutionsArray, institutionsObject],
   );
 
   return (

--- a/src/app/components/layout/Browse.tsx
+++ b/src/app/components/layout/Browse.tsx
@@ -10,7 +10,7 @@ import { College } from "../../types";
 import arrow_upward from "../../assets/icons/arrow_upward.svg";
 
 export const Browse = () => {
-  const { institutionData } = useContext(InstitutionContext);
+  const { institutionsArray } = useContext(InstitutionContext);
   const [scrollPosition, setScrollPosition] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
 
@@ -41,7 +41,7 @@ export const Browse = () => {
         <FilterModal closeHandler={() => setIsModalVisible(false)} />
       )}
       <ul className="usa-card-group">
-        {institutionData?.map((school: College) => (
+        {institutionsArray?.map((school: College) => (
           <CollegeCard key={school.id} college={school} />
         ))}
       </ul>

--- a/src/app/testing/jest/frontend/ConfirmationPage.test.tsx
+++ b/src/app/testing/jest/frontend/ConfirmationPage.test.tsx
@@ -11,7 +11,9 @@ const testParams = {
   id: 0,
 };
 
-const testContext: InstitutionContextShape = { institutionData: [mockCollege] };
+const testContext: InstitutionContextShape = {
+  institutionsArray: [mockCollege],
+};
 
 const testConfirmationPageComponent = () => (
   <InstitutionContext.Provider value={testContext}>

--- a/src/app/testing/jest/frontend/DetailsPage.test.tsx
+++ b/src/app/testing/jest/frontend/DetailsPage.test.tsx
@@ -9,7 +9,9 @@ const testParams = {
   id: 0,
 };
 
-const testContext: InstitutionContextShape = { institutionData: [mockCollege] };
+const testContext: InstitutionContextShape = {
+  institutionsArray: [mockCollege],
+};
 
 const testDetailsPageComponent = () => (
   <InstitutionContext.Provider value={testContext}>


### PR DESCRIPTION
## Summary

We need the institutions data available in both array and object form. This PR converts the array results to an object (indexed by institution id) and stores them alongside the array results in the provider.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How To Test
Pull it down and use it

## Checklist
- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation, including any applicable ADRs~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that fail without these changes~
- ~[ ] New and existing tests (unit, integration, accessibility) pass locally~
- ~[ ] Documentation updated~
- ~[ ] If there are security concerns they are addressed or ticketed after being discussed~
