### PR TITLE
Add close app modal

### DIFF
--- a/src/app/components/form/AppForm.tsx
+++ b/src/app/components/form/AppForm.tsx
@@ -2,7 +2,6 @@
 
 import * as yup from "yup";
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 // components
 import {
@@ -12,7 +11,13 @@ import {
   CardBody,
   GridContainer,
 } from "@trussworks/react-uswds";
-import { Spinner, TextArea, TextField, USWDSForm } from "../index";
+import {
+  CloseAppModal,
+  Spinner,
+  TextArea,
+  TextField,
+  USWDSForm,
+} from "@/src/app/components";
 // pages
 import NotFound from "../../not-found";
 // utils
@@ -27,6 +32,15 @@ export const AppForm = ({ institutionId }: Props) => {
     Record<string, any> | undefined
   >();
   const [loading, setLoading] = useState(true);
+  const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+
+  const launchModal = () => {
+    setIsModalVisible(true);
+  };
+
+  const closeModal = () => {
+    setIsModalVisible(false);
+  };
 
   const appq = application?.questions;
 
@@ -232,13 +246,18 @@ export const AppForm = ({ institutionId }: Props) => {
         </GridContainer>
         <div className="application_footer">
           <ButtonGroup className="application_footer-buttons">
-            <Link href={"/"} className="usa-button usa-button--unstyled">
+            <Button
+              type="button"
+              onClick={launchModal}
+              className="usa-button usa-button--unstyled"
+            >
               Close application
-            </Link>
+            </Button>
             <Button type={"submit"}>Submit application</Button>
           </ButtonGroup>
         </div>
       </USWDSForm>
+      {isModalVisible && <CloseAppModal closeHandler={closeModal} />}
     </div>
   );
 

--- a/src/app/components/index.tsx
+++ b/src/app/components/index.tsx
@@ -14,6 +14,7 @@ export { HeroImage } from "./layout/HeroImage";
 export { PageHeader } from "./layout/PageHeader";
 export { PageFooter } from "./layout/PageFooter";
 // modal elements
+export { CloseAppModal } from "./modals/CloseAppModal";
 export { FilterModal } from "./modals/FilterModal";
 // utilities
 export { Spinner } from "./utilities/Spinner";

--- a/src/app/components/modals/CloseAppModal.tsx
+++ b/src/app/components/modals/CloseAppModal.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { MouseEventHandler } from "react";
+//components
+import Image from "next/image";
+import {
+  Button,
+  ButtonGroup,
+  ModalFooter,
+  ModalHeading,
+} from "@trussworks/react-uswds";
+//assets
+import close from "../../assets/icons/close.svg";
+import Link from "next/link";
+
+export const CloseAppModal = ({ closeHandler }: Props) => {
+  return (
+    <div
+      role="dialog"
+      className="usa-modal-wrapper is-visible"
+      aria-labelledby="modal-1-heading"
+      aria-describedby="modal-1-description"
+    >
+      <div data-testid="modalOverlay" className="usa-modal-overlay">
+        <div className="usa-modal usa-close-app-modal--lg" tabIndex={-1}>
+          <ModalHeading>
+            Are you sure you want to close the application?
+          </ModalHeading>
+          <p>You have unsaved changes that will be lost. </p>
+          <ModalFooter>
+            <ButtonGroup>
+              <Link href={"/"} className="usa-button">
+                Close application
+              </Link>
+              <Button
+                type="button"
+                onClick={closeHandler as MouseEventHandler}
+                unstyled
+                className="padding-105 text-center"
+              >
+                Cancel
+              </Button>
+            </ButtonGroup>
+          </ModalFooter>
+          <button
+            type="button"
+            className="usa-button usa-modal__close filter_close"
+            aria-label="Close this window"
+            data-close-modal
+            onClick={closeHandler as MouseEventHandler}
+          >
+            <Image
+              src={close}
+              className="filter-modal_icon-image"
+              height="30"
+              width="30"
+              alt="close icon"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface Props {
+  closeHandler: Function;
+}

--- a/src/app/styles/components/modals/CloseAppModal.scss
+++ b/src/app/styles/components/modals/CloseAppModal.scss
@@ -1,0 +1,9 @@
+@use "uswds-core" as *;
+
+.usa-close-app-modal--lg {
+  @include u-padding(3);
+  position: absolute;
+  top: 10vh;
+  left: 0;
+  right: 0;
+}

--- a/src/app/styles/styles.scss
+++ b/src/app/styles/styles.scss
@@ -20,4 +20,5 @@
 @forward "./components/layout/PageHeader.scss";
 @forward "./components/layout/PageFooter.scss";
 @forward "./components/utilities/Spinner.scss";
+@forward "./components/modals/CloseAppModal.scss";
 @forward "./components/modals/FilterModal.scss";

--- a/src/app/testing/jest/frontend/components/modals/CloseAppModal.test.tsx
+++ b/src/app/testing/jest/frontend/components/modals/CloseAppModal.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { CloseAppModal } from "@/src/app/components";
+
+const mockCloseHandler = jest.fn();
+
+const testCloseAppModalComponent = () => (
+  <CloseAppModal closeHandler={mockCloseHandler} />
+);
+
+describe("test CloseAppModal", () => {
+  it("renders", () => {
+    render(testCloseAppModalComponent());
+    expect(
+      screen.getByText("Are you sure you want to close the application?"),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: "Close application" }),
+    ).toHaveAttribute("href", "/");
+  });
+});


### PR DESCRIPTION
# Summary

Add modal to verify user wants to close the college app before doing so

Fixes #204

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How To Test
- Go to an application
- Click "Close application"
- Verify it shows the modal and modal actions do what you expect

# Checklist:

- [x] My code follows the style guidelines of this project and has no linting errors
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, including any applicable ADRs
- [x] My changes generate no new warnings
- [x] I have added tests that fail without these changes
- [x] New and existing tests (unit, integration, accessibility) pass locally
- [ ] Documentation updated
- [ ] If there are security concerns they are addressed or ticketed after being discussed
